### PR TITLE
Fix php 8 error

### DIFF
--- a/src/DineshBarcode/QRcode.php
+++ b/src/DineshBarcode/QRcode.php
@@ -179,7 +179,8 @@ if (!defined('QRCODEDEFS')) {
  * @author Dinesh Rabara
  * @version 1.0.009
  */
-class QRcode {
+class QRcode
+{
 
     /**
      * Barcode array to be returned which is readable by Dinesh Rabara.
@@ -525,9 +526,10 @@ class QRcode {
      * @public
      * @since 1.0.000
      */
-    public function __construct($code, $eclevel = 'L') {
+    public function __construct($code, $eclevel = 'L')
+    {
         $barcode_array = array();
-        if ((is_null($code)) OR ($code == '\0') OR ($code == '')) {
+        if ((is_null($code)) or ($code == '\0') or ($code == '')) {
             return false;
         }
         // set error correction level
@@ -535,10 +537,10 @@ class QRcode {
         if ($this->level === false) {
             $this->level = QR_ECLEVEL_L;
         }
-        if (($this->hint != QR_MODE_8B) AND ($this->hint != QR_MODE_KJ)) {
+        if (($this->hint != QR_MODE_8B) and ($this->hint != QR_MODE_KJ)) {
             return false;
         }
-        if (($this->version < 0) OR ($this->version > QRSPEC_VERSION_MAX)) {
+        if (($this->version < 0) or ($this->version > QRSPEC_VERSION_MAX)) {
             return false;
         }
         $this->items = array();
@@ -566,7 +568,8 @@ class QRcode {
      * @return array barcode array readable by Dinesh Rabara;
      * @public
      */
-    public function getBarcodeArray() {
+    public function getBarcodeArray()
+    {
         return $this->barcode_array;
     }
 
@@ -575,7 +578,8 @@ class QRcode {
      * @param $frame (array) array to binarize
      * @return array frame in binary form
      */
-    protected function binarize($frame) {
+    protected function binarize($frame)
+    {
         $len = count($frame);
         // the frame is square (width = height)
         foreach ($frame as &$frameLine) {
@@ -590,7 +594,8 @@ class QRcode {
      * Encode the input string to QR code
      * @param $string (string) input string to encode
      */
-    protected function encodeString($string) {
+    protected function encodeString($string)
+    {
         $this->dataStr = $string;
         if (!$this->casesensitive) {
             $this->toUpper();
@@ -606,7 +611,8 @@ class QRcode {
      * Encode mask
      * @param $mask (int) masking mode
      */
-    protected function encodeMask($mask) {
+    protected function encodeMask($mask)
+    {
         $spec = array(0, 0, 0, 0, 0);
         $this->datacode = $this->getByteStream($this->items);
         if (is_null($this->datacode)) {
@@ -614,6 +620,7 @@ class QRcode {
         }
         $spec = $this->getEccSpec($this->version, $this->level, $spec);
         $this->b1 = $this->rsBlockNum1($spec);
+
         $this->dataLength = $this->rsDataLength($spec);
         $this->eccLength = $this->rsEccLength($spec);
         $this->ecccode = array_fill(0, $this->eccLength, 0);
@@ -670,7 +677,8 @@ class QRcode {
      * @param $at (array) x,y position
      * @param $val (int) value of the character to set
      */
-    protected function setFrameAt($at, $val) {
+    protected function setFrameAt($at, $val)
+    {
         $this->frame[$at['y']][$at['x']] = chr($val);
     }
 
@@ -679,7 +687,8 @@ class QRcode {
      * @param $at (array) x,y position
      * @return value at specified position
      */
-    protected function getFrameAt($at) {
+    protected function getFrameAt($at)
+    {
         return ord($this->frame[$at['y']][$at['x']]);
     }
 
@@ -687,7 +696,8 @@ class QRcode {
      * Return the next frame position
      * @return array of x,y coordinates
      */
-    protected function getNextPosition() {
+    protected function getNextPosition()
+    {
         do {
             if ($this->bit == -1) {
                 $this->bit = 0;
@@ -725,7 +735,7 @@ class QRcode {
                     }
                 }
             }
-            if (($x < 0) OR ($y < 0)) {
+            if (($x < 0) or ($y < 0)) {
                 return NULL;
             }
             $this->x = $x;
@@ -742,7 +752,8 @@ class QRcode {
      * @param $spec (array) array of ECC specification
      * @return 0 in case of success, -1 in case of error
      */
-    protected function init($spec) {
+    protected function init($spec)
+    {
         $dl = $this->rsDataCodes1($spec);
         $el = $this->rsEccCodes1($spec);
         $rs = $this->init_rs(8, 0x11d, 0, 1, $el, 255 - $dl - $el);
@@ -793,17 +804,24 @@ class QRcode {
      * Return Reed-Solomon block code.
      * @return array rsblocks
      */
-    protected function getCode() {
+    protected function getCode()
+    {
         if ($this->count < $this->dataLength) {
             $row = $this->count % $this->blocks;
             $col = $this->count / $this->blocks;
             if ($col >= $this->rsblocks[0]['dataLength']) {
                 $row += $this->b1;
             }
+            if (is_float($col)) {
+                $col = (int) floor($col);
+            }
             $ret = $this->rsblocks[$row]['data'][$col];
         } elseif ($this->count < $this->dataLength + $this->eccLength) {
             $row = ($this->count - $this->dataLength) % $this->blocks;
             $col = ($this->count - $this->dataLength) / $this->blocks;
+            if (is_float($col)) {
+                $col = (int) floor($col);
+            }
             $ret = $this->rsblocks[$row]['ecc'][$col];
         } else {
             return 0;
@@ -823,7 +841,8 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int blacks
      */
-    protected function writeFormatInformation($width, &$frame, $mask, $level) {
+    protected function writeFormatInformation($width, &$frame, $mask, $level)
+    {
         $blacks = 0;
         $format = $this->getFormatInfo($mask, $level);
         for ($i = 0; $i < 8; ++$i) {
@@ -865,7 +884,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask0($x, $y) {
+    protected function mask0($x, $y)
+    {
         return ($x + $y) & 1;
     }
 
@@ -875,7 +895,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask1($x, $y) {
+    protected function mask1($x, $y)
+    {
         return ($y & 1);
     }
 
@@ -885,7 +906,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask2($x, $y) {
+    protected function mask2($x, $y)
+    {
         return ($x % 3);
     }
 
@@ -895,7 +917,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask3($x, $y) {
+    protected function mask3($x, $y)
+    {
         return ($x + $y) % 3;
     }
 
@@ -905,7 +928,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask4($x, $y) {
+    protected function mask4($x, $y)
+    {
         return (((int) ($y / 2)) + ((int) ($x / 3))) & 1;
     }
 
@@ -915,7 +939,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask5($x, $y) {
+    protected function mask5($x, $y)
+    {
         return (($x * $y) & 1) + ($x * $y) % 3;
     }
 
@@ -925,7 +950,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask6($x, $y) {
+    protected function mask6($x, $y)
+    {
         return ((($x * $y) & 1) + ($x * $y) % 3) & 1;
     }
 
@@ -935,7 +961,8 @@ class QRcode {
      * @param $y (int) Y position
      * @return int mask
      */
-    protected function mask7($x, $y) {
+    protected function mask7($x, $y)
+    {
         return ((($x * $y) % 3) + (($x + $y) & 1)) & 1;
     }
 
@@ -946,7 +973,8 @@ class QRcode {
      * @param $frame (array) frame
      * @return array bitmask
      */
-    protected function generateMaskNo($maskNo, $width, $frame) {
+    protected function generateMaskNo($maskNo, $width, $frame)
+    {
         $bitMask = array_fill(0, $width, array_fill(0, $width, 0));
         for ($y = 0; $y < $width; ++$y) {
             for ($x = 0; $x < $width; ++$x) {
@@ -970,7 +998,8 @@ class QRcode {
      * @param $maskGenOnly (boolean)
      * @return int b
      */
-    protected function makeMaskNo($maskNo, $width, $s, &$d, $maskGenOnly = false) {
+    protected function makeMaskNo($maskNo, $width, $s, &$d, $maskGenOnly = false)
+    {
         $b = 0;
         $bitMask = array();
         $bitMask = $this->generateMaskNo($maskNo, $width, $s, $d);
@@ -997,7 +1026,8 @@ class QRcode {
      * @param $level (int)
      * @return array mask
      */
-    protected function makeMask($width, $frame, $maskNo, $level) {
+    protected function makeMask($width, $frame, $maskNo, $level)
+    {
         $masked = array_fill(0, $width, str_repeat("\0", $width));
         $this->makeMaskNo($maskNo, $width, $frame, $masked);
         $this->writeFormatInformation($width, $masked, $maskNo, $level);
@@ -1009,22 +1039,24 @@ class QRcode {
      * @param $length (int)
      * @return int demerit
      */
-    protected function calcN1N3($length) {
+    protected function calcN1N3($length)
+    {
         $demerit = 0;
         for ($i = 0; $i < $length; ++$i) {
             if ($this->runLength[$i] >= 5) {
                 $demerit += (N1 + ($this->runLength[$i] - 5));
             }
             if ($i & 1) {
-                if (($i >= 3) AND ($i < ($length - 2)) AND ($this->runLength[$i] % 3 == 0)) {
+                if (($i >= 3) and ($i < ($length - 2)) and ($this->runLength[$i] % 3 == 0)) {
                     $fact = (int) ($this->runLength[$i] / 3);
                     if (($this->runLength[$i - 2] == $fact)
-                            AND ($this->runLength[$i - 1] == $fact)
-                            AND ($this->runLength[$i + 1] == $fact)
-                            AND ($this->runLength[$i + 2] == $fact)) {
-                        if (($this->runLength[$i - 3] < 0) OR ($this->runLength[$i - 3] >= (4 * $fact))) {
+                        and ($this->runLength[$i - 1] == $fact)
+                        and ($this->runLength[$i + 1] == $fact)
+                        and ($this->runLength[$i + 2] == $fact)
+                    ) {
+                        if (($this->runLength[$i - 3] < 0) or ($this->runLength[$i - 3] >= (4 * $fact))) {
                             $demerit += N3;
-                        } elseif ((($i + 3) >= $length) OR ($this->runLength[$i + 3] >= (4 * $fact))) {
+                        } elseif ((($i + 3) >= $length) or ($this->runLength[$i + 3] >= (4 * $fact))) {
                             $demerit += N3;
                         }
                     }
@@ -1040,7 +1072,8 @@ class QRcode {
      * @param $frame (array)
      * @return int demerit
      */
-    protected function evaluateSymbol($width, $frame) {
+    protected function evaluateSymbol($width, $frame)
+    {
         $head = 0;
         $demerit = 0;
         for ($y = 0; $y < $width; ++$y) {
@@ -1051,14 +1084,14 @@ class QRcode {
                 $frameYM = $frame[$y - 1];
             }
             for ($x = 0; $x < $width; ++$x) {
-                if (($x > 0) AND ($y > 0)) {
+                if (($x > 0) and ($y > 0)) {
                     $b22 = ord($frameY[$x]) & ord($frameY[$x - 1]) & ord($frameYM[$x]) & ord($frameYM[$x - 1]);
                     $w22 = ord($frameY[$x]) | ord($frameY[$x - 1]) | ord($frameYM[$x]) | ord($frameYM[$x - 1]);
                     if (($b22 | ($w22 ^ 1)) & 1) {
                         $demerit += N2;
                     }
                 }
-                if (($x == 0) AND (ord($frameY[$x]) & 1)) {
+                if (($x == 0) and (ord($frameY[$x]) & 1)) {
                     $this->runLength[0] = -1;
                     $head = 1;
                     $this->runLength[$head] = 1;
@@ -1077,7 +1110,7 @@ class QRcode {
             $head = 0;
             $this->runLength[0] = 1;
             for ($y = 0; $y < $width; ++$y) {
-                if (($y == 0) AND (ord($frame[$y][$x]) & 1)) {
+                if (($y == 0) and (ord($frame[$y][$x]) & 1)) {
                     $this->runLength[0] = -1;
                     $head = 1;
                     $this->runLength[$head] = 1;
@@ -1102,7 +1135,8 @@ class QRcode {
      * @param $level (int)
      * @return array best mask
      */
-    protected function mask($width, $frame, $level) {
+    protected function mask($width, $frame, $level)
+    {
         $minDemerit = PHP_INT_MAX;
         $bestMaskNum = 0;
         $bestMask = array();
@@ -1143,7 +1177,8 @@ class QRcode {
      * @param $pos (int) characted position
      * @return boolean true of false
      */
-    protected function isdigitat($str, $pos) {
+    protected function isdigitat($str, $pos)
+    {
         if ($pos >= strlen($str)) {
             return false;
         }
@@ -1156,7 +1191,8 @@ class QRcode {
      * @param $pos (int) characted position
      * @return boolean true of false
      */
-    protected function isalnumat($str, $pos) {
+    protected function isalnumat($str, $pos)
+    {
         if ($pos >= strlen($str)) {
             return false;
         }
@@ -1168,7 +1204,8 @@ class QRcode {
      * @param $pos (int)
      * @return int mode
      */
-    protected function identifyMode($pos) {
+    protected function identifyMode($pos)
+    {
         if ($pos >= strlen($this->dataStr)) {
             return QR_MODE_NL;
         }
@@ -1181,7 +1218,7 @@ class QRcode {
             if ($pos + 1 < strlen($this->dataStr)) {
                 $d = $this->dataStr[$pos + 1];
                 $word = (ord($c) << 8) | ord($d);
-                if (($word >= 0x8140 && $word <= 0x9ffc) OR ($word >= 0xe040 && $word <= 0xebbf)) {
+                if (($word >= 0x8140 && $word <= 0x9ffc) or ($word >= 0xe040 && $word <= 0xebbf)) {
                     return QR_MODE_KJ;
                 }
             }
@@ -1193,7 +1230,8 @@ class QRcode {
      * eatNum
      * @return int run
      */
-    protected function eatNum() {
+    protected function eatNum()
+    {
         $ln = $this->lengthIndicator(QR_MODE_NM, $this->version);
         $p = 0;
         while ($this->isdigitat($this->dataStr, $p)) {
@@ -1203,16 +1241,16 @@ class QRcode {
         $mode = $this->identifyMode($p);
         if ($mode == QR_MODE_8B) {
             $dif = $this->estimateBitsModeNum($run) + 4 + $ln
-                    + $this->estimateBitsMode8(1)         // + 4 + l8
-                    - $this->estimateBitsMode8($run + 1); // - 4 - l8
+                + $this->estimateBitsMode8(1)         // + 4 + l8
+                - $this->estimateBitsMode8($run + 1); // - 4 - l8
             if ($dif > 0) {
                 return $this->eat8();
             }
         }
         if ($mode == QR_MODE_AN) {
             $dif = $this->estimateBitsModeNum($run) + 4 + $ln
-                    + $this->estimateBitsModeAn(1)        // + 4 + la
-                    - $this->estimateBitsModeAn($run + 1); // - 4 - la
+                + $this->estimateBitsModeAn(1)        // + 4 + la
+                - $this->estimateBitsModeAn($run + 1); // - 4 - la
             if ($dif > 0) {
                 return $this->eatAn();
             }
@@ -1225,7 +1263,8 @@ class QRcode {
      * eatAn
      * @return int run
      */
-    protected function eatAn() {
+    protected function eatAn()
+    {
         $la = $this->lengthIndicator(QR_MODE_AN, $this->version);
         $ln = $this->lengthIndicator(QR_MODE_NM, $this->version);
         $p = 1;
@@ -1236,8 +1275,8 @@ class QRcode {
                     $q++;
                 }
                 $dif = $this->estimateBitsModeAn($p) // + 4 + la
-                        + $this->estimateBitsModeNum($q - $p) + 4 + $ln
-                        - $this->estimateBitsModeAn($q); // - 4 - la
+                    + $this->estimateBitsModeNum($q - $p) + 4 + $ln
+                    - $this->estimateBitsModeAn($q); // - 4 - la
                 if ($dif < 0) {
                     break;
                 } else {
@@ -1250,8 +1289,8 @@ class QRcode {
         $run = $p;
         if (!$this->isalnumat($this->dataStr, $p)) {
             $dif = $this->estimateBitsModeAn($run) + 4 + $la
-                    + $this->estimateBitsMode8(1) // + 4 + l8
-                    - $this->estimateBitsMode8($run + 1); // - 4 - l8
+                + $this->estimateBitsMode8(1) // + 4 + l8
+                - $this->estimateBitsMode8($run + 1); // - 4 - l8
             if ($dif > 0) {
                 return $this->eat8();
             }
@@ -1264,7 +1303,8 @@ class QRcode {
      * eatKanji
      * @return int run
      */
-    protected function eatKanji() {
+    protected function eatKanji()
+    {
         $p = 0;
         while ($this->identifyMode($p) == QR_MODE_KJ) {
             $p += 2;
@@ -1277,7 +1317,8 @@ class QRcode {
      * eat8
      * @return int run
      */
-    protected function eat8() {
+    protected function eat8()
+    {
         $la = $this->lengthIndicator(QR_MODE_AN, $this->version);
         $ln = $this->lengthIndicator(QR_MODE_NM, $this->version);
         $p = 1;
@@ -1293,8 +1334,8 @@ class QRcode {
                     $q++;
                 }
                 $dif = $this->estimateBitsMode8($p) // + 4 + l8
-                        + $this->estimateBitsModeNum($q - $p) + 4 + $ln
-                        - $this->estimateBitsMode8($q); // - 4 - l8
+                    + $this->estimateBitsModeNum($q - $p) + 4 + $ln
+                    - $this->estimateBitsMode8($q); // - 4 - l8
                 if ($dif < 0) {
                     break;
                 } else {
@@ -1306,8 +1347,8 @@ class QRcode {
                     $q++;
                 }
                 $dif = $this->estimateBitsMode8($p)  // + 4 + l8
-                        + $this->estimateBitsModeAn($q - $p) + 4 + $la
-                        - $this->estimateBitsMode8($q); // - 4 - l8
+                    + $this->estimateBitsModeAn($q - $p) + 4 + $la
+                    - $this->estimateBitsMode8($q); // - 4 - l8
                 if ($dif < 0) {
                     break;
                 } else {
@@ -1325,7 +1366,8 @@ class QRcode {
     /**
      * splitString
      */
-    protected function splitString() {
+    protected function splitString()
+    {
         while (strlen($this->dataStr) > 0) {
             if ($this->dataStr == '') {
                 return 0;
@@ -1366,7 +1408,8 @@ class QRcode {
     /**
      * toUpper
      */
-    protected function toUpper() {
+    protected function toUpper()
+    {
         $stringLen = strlen($this->dataStr);
         $p = 0;
         while ($p < $stringLen) {
@@ -1374,7 +1417,7 @@ class QRcode {
             if ($mode == QR_MODE_KJ) {
                 $p += 2;
             } else {
-                if ((ord($this->dataStr[$p]) >= ord('a')) AND (ord($this->dataStr[$p]) <= ord('z'))) {
+                if ((ord($this->dataStr[$p]) >= ord('a')) and (ord($this->dataStr[$p]) <= ord('z'))) {
                     $this->dataStr[$p] = chr(ord($this->dataStr[$p]) - 32);
                 }
                 $p++;
@@ -1394,7 +1437,8 @@ class QRcode {
      * @param $bstream (array)
      * @return array input item
      */
-    protected function newInputItem($mode, $size, $data, $bstream = null) {
+    protected function newInputItem($mode, $size, $data, $bstream = null)
+    {
         $setData = array_slice($data, 0, $size);
         if (count($setData) < $size) {
             $setData = array_merge($setData, array_fill(0, ($size - count($setData)), 0));
@@ -1416,7 +1460,8 @@ class QRcode {
      * @param $version (int)
      * @return array input item
      */
-    protected function encodeModeNum($inputitem, $version) {
+    protected function encodeModeNum($inputitem, $version)
+    {
         $words = (int) ($inputitem['size'] / 3);
         $inputitem['bstream'] = array();
         $val = 0x1;
@@ -1445,7 +1490,8 @@ class QRcode {
      * @param $version (int)
      * @return array input item
      */
-    protected function encodeModeAn($inputitem, $version) {
+    protected function encodeModeAn($inputitem, $version)
+    {
         $words = (int) ($inputitem['size'] / 2);
         $inputitem['bstream'] = array();
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], 4, 0x02);
@@ -1468,7 +1514,8 @@ class QRcode {
      * @param $version (int)
      * @return array input item
      */
-    protected function encodeMode8($inputitem, $version) {
+    protected function encodeMode8($inputitem, $version)
+    {
         $inputitem['bstream'] = array();
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], 4, 0x4);
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], $this->lengthIndicator(QR_MODE_8B, $version), $inputitem['size']);
@@ -1484,11 +1531,12 @@ class QRcode {
      * @param $version (int)
      * @return array input item
      */
-    protected function encodeModeKanji($inputitem, $version) {
+    protected function encodeModeKanji($inputitem, $version)
+    {
         $inputitem['bstream'] = array();
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], 4, 0x8);
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], $this->lengthIndicator(QR_MODE_KJ, $version), (int) ($inputitem['size'] / 2));
-        for ($i = 0; $i < $inputitem['size']; $i+=2) {
+        for ($i = 0; $i < $inputitem['size']; $i += 2) {
             $val = (ord($inputitem['data'][$i]) << 8) | ord($inputitem['data'][$i + 1]);
             if ($val <= 0x9ffc) {
                 $val -= 0x8140;
@@ -1507,7 +1555,8 @@ class QRcode {
      * @param $inputitem (array)
      * @return array input item
      */
-    protected function encodeModeStructure($inputitem) {
+    protected function encodeModeStructure($inputitem)
+    {
         $inputitem['bstream'] = array();
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], 4, 0x03);
         $inputitem['bstream'] = $this->appendNum($inputitem['bstream'], 4, ord($inputitem['data'][1]) - 1);
@@ -1522,7 +1571,8 @@ class QRcode {
      * @param $version (int)
      * @return array input item
      */
-    protected function encodeBitStream($inputitem, $version) {
+    protected function encodeBitStream($inputitem, $version)
+    {
         $inputitem['bstream'] = array();
         $words = $this->maximumWords($inputitem['mode'], $version);
         if ($inputitem['size'] > $words) {
@@ -1576,7 +1626,8 @@ class QRcode {
      * @return items
      *
      */
-    protected function appendNewInputItem($items, $mode, $size, $data) {
+    protected function appendNewInputItem($items, $mode, $size, $data)
+    {
         $newitem = $this->newInputItem($mode, $size, $data);
         if (!empty($newitem)) {
             $items[] = $newitem;
@@ -1592,11 +1643,12 @@ class QRcode {
      * @param $parity (int)
      * @return array items
      */
-    protected function insertStructuredAppendHeader($items, $size, $index, $parity) {
+    protected function insertStructuredAppendHeader($items, $size, $index, $parity)
+    {
         if ($size > MAX_STRUCTURED_SYMBOLS) {
             return -1;
         }
-        if (($index <= 0) OR ($index > MAX_STRUCTURED_SYMBOLS)) {
+        if (($index <= 0) or ($index > MAX_STRUCTURED_SYMBOLS)) {
             return -1;
         }
         $buf = array($size, $index, $parity);
@@ -1610,7 +1662,8 @@ class QRcode {
      * @param $items (array)
      * @return int parity
      */
-    protected function calcParity($items) {
+    protected function calcParity($items)
+    {
         $parity = 0;
         foreach ($items as $item) {
             if ($item['mode'] != QR_MODE_ST) {
@@ -1628,9 +1681,10 @@ class QRcode {
      * @param $data (array)
      * @return boolean true or false
      */
-    protected function checkModeNum($size, $data) {
+    protected function checkModeNum($size, $data)
+    {
         for ($i = 0; $i < $size; ++$i) {
-            if ((ord($data[$i]) < ord('0')) OR (ord($data[$i]) > ord('9'))) {
+            if ((ord($data[$i]) < ord('0')) or (ord($data[$i]) > ord('9'))) {
                 return false;
             }
         }
@@ -1642,7 +1696,8 @@ class QRcode {
      * @param $c (int) character value
      * @return value
      */
-    protected function lookAnTable($c) {
+    protected function lookAnTable($c)
+    {
         return (($c > 127) ? -1 : $this->anTable[$c]);
     }
 
@@ -1652,7 +1707,8 @@ class QRcode {
      * @param $data (array)
      * @return boolean true or false
      */
-    protected function checkModeAn($size, $data) {
+    protected function checkModeAn($size, $data)
+    {
         for ($i = 0; $i < $size; ++$i) {
             if ($this->lookAnTable(ord($data[$i])) == -1) {
                 return false;
@@ -1666,7 +1722,8 @@ class QRcode {
      * @param $size (int)
      * @return int number of bits
      */
-    protected function estimateBitsModeNum($size) {
+    protected function estimateBitsModeNum($size)
+    {
         $w = (int) ($size / 3);
         $bits = ($w * 10);
         switch ($size - ($w * 3)) {
@@ -1687,7 +1744,8 @@ class QRcode {
      * @param $size (int)
      * @return int number of bits
      */
-    protected function estimateBitsModeAn($size) {
+    protected function estimateBitsModeAn($size)
+    {
         $bits = (int) ($size * 5.5); // (size / 2 ) * 11
         if ($size & 1) {
             $bits += 6;
@@ -1700,7 +1758,8 @@ class QRcode {
      * @param $size (int)
      * @return int number of bits
      */
-    protected function estimateBitsMode8($size) {
+    protected function estimateBitsMode8($size)
+    {
         return (int) ($size * 8);
     }
 
@@ -1709,7 +1768,8 @@ class QRcode {
      * @param $size (int)
      * @return int number of bits
      */
-    protected function estimateBitsModeKanji($size) {
+    protected function estimateBitsModeKanji($size)
+    {
         return (int) ($size * 6.5); // (size / 2 ) * 13
     }
 
@@ -1719,13 +1779,14 @@ class QRcode {
      * @param $data (array)
      * @return boolean true or false
      */
-    protected function checkModeKanji($size, $data) {
+    protected function checkModeKanji($size, $data)
+    {
         if ($size & 1) {
             return false;
         }
-        for ($i = 0; $i < $size; $i+=2) {
+        for ($i = 0; $i < $size; $i += 2) {
             $val = (ord($data[$i]) << 8) | ord($data[$i + 1]);
-            if (($val < 0x8140) OR (($val > 0x9ffc) AND ($val < 0xe040)) OR ($val > 0xebbf)) {
+            if (($val < 0x8140) or (($val > 0x9ffc) and ($val < 0xe040)) or ($val > 0xebbf)) {
                 return false;
             }
         }
@@ -1739,7 +1800,8 @@ class QRcode {
      * @param $data (array) data to validate
      * @return boolean true in case of valid data, false otherwise
      */
-    protected function check($mode, $size, $data) {
+    protected function check($mode, $size, $data)
+    {
         if ($size <= 0) {
             return false;
         }
@@ -1772,7 +1834,8 @@ class QRcode {
      * @param $version (int)
      * @return int bits
      */
-    protected function estimateBitStreamSize($items, $version) {
+    protected function estimateBitStreamSize($items, $version)
+    {
         $bits = 0;
         if ($version == 0) {
             $version = 1;
@@ -1815,7 +1878,8 @@ class QRcode {
      * @param $items (array)
      * @return int version
      */
-    protected function estimateVersion($items) {
+    protected function estimateVersion($items)
+    {
         $version = 0;
         $prev = 0;
         do {
@@ -1836,7 +1900,8 @@ class QRcode {
      * @param $bits (int)
      * @return int size
      */
-    protected function lengthOfCode($mode, $version, $bits) {
+    protected function lengthOfCode($mode, $version, $bits)
+    {
         $payload = $bits - 4 - $this->lengthIndicator($mode, $version);
         switch ($mode) {
             case QR_MODE_NM: {
@@ -1891,7 +1956,8 @@ class QRcode {
      * @param $items (array)
      * @return array of items and total bits
      */
-    protected function createBitStream($items) {
+    protected function createBitStream($items)
+    {
         $total = 0;
         foreach ($items as $key => $item) {
             $items[$key] = $this->encodeBitStream($item, $this->version);
@@ -1906,7 +1972,8 @@ class QRcode {
      * @param $items (array)
      * @return array items
      */
-    protected function convertData($items) {
+    protected function convertData($items)
+    {
         $ver = $this->estimateVersion($items);
         if ($ver > $this->version) {
             $this->version = $ver;
@@ -1935,7 +2002,8 @@ class QRcode {
      * @param $bstream (array)
      * @return array bitstream
      */
-    protected function appendPaddingBit($bstream) {
+    protected function appendPaddingBit($bstream)
+    {
         if (is_null($bstream)) {
             return null;
         }
@@ -1968,7 +2036,8 @@ class QRcode {
      * @param $items (array) items
      * @return array bitstream
      */
-    protected function mergeBitStream($items) {
+    protected function mergeBitStream($items)
+    {
         $items = $this->convertData($items);
         if (!is_array($items)) {
             return null;
@@ -1985,7 +2054,8 @@ class QRcode {
      * @param $items (int)
      * @return array padded merged byte stream
      */
-    protected function getBitStream($items) {
+    protected function getBitStream($items)
+    {
         $bstream = $this->mergeBitStream($items);
         return $this->appendPaddingBit($bstream);
     }
@@ -1995,7 +2065,8 @@ class QRcode {
      * @param $items (int)
      * @return array padded merged byte stream
      */
-    protected function getByteStream($items) {
+    protected function getByteStream($items)
+    {
         $bstream = $this->getBitStream($items);
         return $this->bitstreamToByte($bstream);
     }
@@ -2008,7 +2079,8 @@ class QRcode {
      * @param $setLength (int) array size
      * @return array
      */
-    protected function allocate($setLength) {
+    protected function allocate($setLength)
+    {
         return array_fill(0, $setLength, 0);
     }
 
@@ -2018,7 +2090,8 @@ class QRcode {
      * @param $num (int) number
      * @return array bitstream
      */
-    protected function newFromNum($bits, $num) {
+    protected function newFromNum($bits, $num)
+    {
         $bstream = $this->allocate($bits);
         $mask = 1 << ($bits - 1);
         for ($i = 0; $i < $bits; ++$i) {
@@ -2038,7 +2111,8 @@ class QRcode {
      * @param $data (array) bytes
      * @return array bitstream
      */
-    protected function newFromBytes($size, $data) {
+    protected function newFromBytes($size, $data)
+    {
         $bstream = $this->allocate($size * 8);
         $p = 0;
         for ($i = 0; $i < $size; ++$i) {
@@ -2062,8 +2136,9 @@ class QRcode {
      * @param $append (array) bitstream to append
      * @return array bitstream
      */
-    protected function appendBitstream($bitstream, $append) {
-        if ((!is_array($append)) OR (count($append) == 0)) {
+    protected function appendBitstream($bitstream, $append)
+    {
+        if ((!is_array($append)) or (count($append) == 0)) {
             return $bitstream;
         }
         if (count($bitstream) == 0) {
@@ -2079,7 +2154,8 @@ class QRcode {
      * @param $num (int) number
      * @return array bitstream
      */
-    protected function appendNum($bitstream, $bits, $num) {
+    protected function appendNum($bitstream, $bits, $num)
+    {
         if ($bits == 0) {
             return 0;
         }
@@ -2094,7 +2170,8 @@ class QRcode {
      * @param $data (array) bytes
      * @return array bitstream
      */
-    protected function appendBytes($bitstream, $size, $data) {
+    protected function appendBytes($bitstream, $size, $data)
+    {
         if ($size == 0) {
             return 0;
         }
@@ -2107,7 +2184,8 @@ class QRcode {
      * @param $bstream (array) original bitstream
      * @return array of bytes
      */
-    protected function bitstreamToByte($bstream) {
+    protected function bitstreamToByte($bstream)
+    {
         if (is_null($bstream)) {
             return null;
         }
@@ -2151,7 +2229,8 @@ class QRcode {
      * @param $replLen (int) length of the repl string
      * @return array srctab
      */
-    protected function qrstrset($srctab, $x, $y, $repl, $replLen = false) {
+    protected function qrstrset($srctab, $x, $y, $repl, $replLen = false)
+    {
         $srctab[$y] = substr_replace($srctab[$y], ($replLen !== false) ? substr($repl, 0, $replLen) : $repl, $x, ($replLen !== false) ? $replLen : strlen($repl));
         return $srctab;
     }
@@ -2162,7 +2241,8 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int maximum size (bytes)
      */
-    protected function getDataLength($version, $level) {
+    protected function getDataLength($version, $level)
+    {
         return $this->capacity[$version][QRCAP_WORDS] - $this->capacity[$version][QRCAP_EC][$level];
     }
 
@@ -2172,7 +2252,8 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int ECC size (bytes)
      */
-    protected function getECCLength($version, $level) {
+    protected function getECCLength($version, $level)
+    {
         return $this->capacity[$version][QRCAP_EC][$level];
     }
 
@@ -2181,7 +2262,8 @@ class QRcode {
      * @param $version (int) version
      * @return int width
      */
-    protected function getWidth($version) {
+    protected function getWidth($version)
+    {
         return $this->capacity[$version][QRCAP_WIDTH];
     }
 
@@ -2190,7 +2272,8 @@ class QRcode {
      * @param $version (int) version
      * @return int number of remainder bits
      */
-    protected function getRemainder($version) {
+    protected function getRemainder($version)
+    {
         return $this->capacity[$version][QRCAP_REMINDER];
     }
 
@@ -2200,7 +2283,8 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int version number
      */
-    protected function getMinimumVersion($size, $level) {
+    protected function getMinimumVersion($size, $level)
+    {
         for ($i = 1; $i <= QRSPEC_VERSION_MAX; ++$i) {
             $words = $this->capacity[$i][QRCAP_WORDS] - $this->capacity[$i][QRCAP_EC][$level];
             if ($words >= $size) {
@@ -2216,7 +2300,8 @@ class QRcode {
      * @param $version (int) version
      * @return int the size of the appropriate length indicator (bits).
      */
-    protected function lengthIndicator($mode, $version) {
+    protected function lengthIndicator($mode, $version)
+    {
         if ($mode == QR_MODE_ST) {
             return 0;
         }
@@ -2236,7 +2321,8 @@ class QRcode {
      * @param $version (int) version
      * @return int the maximum length (bytes)
      */
-    protected function maximumWords($mode, $version) {
+    protected function maximumWords($mode, $version)
+    {
         if ($mode == QR_MODE_ST) {
             return 3;
         }
@@ -2262,7 +2348,8 @@ class QRcode {
      * @param $spec (array) an array of ECC specification contains as following: {# of type1 blocks, # of data code, # of ecc code, # of type2 blocks, # of data code}
      * @return array spec
      */
-    protected function getEccSpec($version, $level, $spec) {
+    protected function getEccSpec($version, $level, $spec)
+    {
         if (count($spec) < 5) {
             $spec = array(0, 0, 0, 0, 0);
         }
@@ -2293,7 +2380,8 @@ class QRcode {
      * @param $oy (int) Y center coordinate of the pattern
      * @return array frame
      */
-    protected function putAlignmentMarker($frame, $ox, $oy) {
+    protected function putAlignmentMarker($frame, $ox, $oy)
+    {
         $finder = array(
             "\xa1\xa1\xa1\xa1\xa1",
             "\xa1\xa0\xa0\xa0\xa1",
@@ -2316,7 +2404,8 @@ class QRcode {
      * @param $width (int) width
      * @return array frame
      */
-    protected function putAlignmentPattern($version, $frame, $width) {
+    protected function putAlignmentPattern($version, $frame, $width)
+    {
         if ($version < 2) {
             return $frame;
         }
@@ -2356,8 +2445,9 @@ class QRcode {
      * @param $version (int) version
      * @return BCH encoded version information pattern
      */
-    protected function getVersionPattern($version) {
-        if (($version < 7) OR ($version > QRSPEC_VERSION_MAX)) {
+    protected function getVersionPattern($version)
+    {
+        if (($version < 7) or ($version > QRSPEC_VERSION_MAX)) {
             return 0;
         }
         return $this->versionPattern[($version - 7)];
@@ -2369,11 +2459,12 @@ class QRcode {
      * @param $level (int) error correction level
      * @return BCH encoded format information pattern
      */
-    protected function getFormatInfo($mask, $level) {
-        if (($mask < 0) OR ($mask > 7)) {
+    protected function getFormatInfo($mask, $level)
+    {
+        if (($mask < 0) or ($mask > 7)) {
             return 0;
         }
-        if (($level < 0) OR ($level > 3)) {
+        if (($level < 0) or ($level > 3)) {
             return 0;
         }
         return $this->formatInfo[$level][$mask];
@@ -2386,7 +2477,8 @@ class QRcode {
      * @param $oy (int) Y center coordinate of the pattern
      * @return array frame
      */
-    protected function putFinderPattern($frame, $ox, $oy) {
+    protected function putFinderPattern($frame, $ox, $oy)
+    {
         $finder = array(
             "\xc1\xc1\xc1\xc1\xc1\xc1\xc1",
             "\xc1\xc0\xc0\xc0\xc0\xc0\xc1",
@@ -2407,7 +2499,8 @@ class QRcode {
      * @param $version (int) version
      * @return Array of unsigned char.
      */
-    protected function createFrame($version) {
+    protected function createFrame($version)
+    {
         $width = $this->capacity[$version][QRCAP_WIDTH];
         $frameLine = str_repeat("\0", $width);
         $frame = array_fill(0, $width, $frameLine);
@@ -2472,8 +2565,9 @@ class QRcode {
      * @param $version (int) version
      * @return Array of unsigned char.
      */
-    protected function newFrame($version) {
-        if (($version < 1) OR ($version > QRSPEC_VERSION_MAX)) {
+    protected function newFrame($version)
+    {
+        if (($version < 1) or ($version > QRSPEC_VERSION_MAX)) {
             return NULL;
         }
         if (!isset($this->frames[$version])) {
@@ -2490,7 +2584,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsBlockNum($spec) {
+    protected function rsBlockNum($spec)
+    {
         return ($spec[0] + $spec[3]);
     }
 
@@ -2499,7 +2594,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsBlockNum1($spec) {
+    protected function rsBlockNum1($spec)
+    {
         return $spec[0];
     }
 
@@ -2508,7 +2604,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsDataCodes1($spec) {
+    protected function rsDataCodes1($spec)
+    {
         return $spec[1];
     }
 
@@ -2517,7 +2614,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsEccCodes1($spec) {
+    protected function rsEccCodes1($spec)
+    {
         return $spec[2];
     }
 
@@ -2526,7 +2624,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsBlockNum2($spec) {
+    protected function rsBlockNum2($spec)
+    {
         return $spec[3];
     }
 
@@ -2535,7 +2634,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsDataCodes2($spec) {
+    protected function rsDataCodes2($spec)
+    {
         return $spec[4];
     }
 
@@ -2544,7 +2644,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsEccCodes2($spec) {
+    protected function rsEccCodes2($spec)
+    {
         return $spec[2];
     }
 
@@ -2553,7 +2654,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsDataLength($spec) {
+    protected function rsDataLength($spec)
+    {
         return ($spec[0] * $spec[1]) + ($spec[3] * $spec[4]);
     }
 
@@ -2562,7 +2664,8 @@ class QRcode {
      * @param $spec (array)
      * @return int value
      */
-    protected function rsEccLength($spec) {
+    protected function rsEccLength($spec)
+    {
         return ($spec[0] + $spec[3]) * $spec[2];
     }
 
@@ -2579,10 +2682,12 @@ class QRcode {
      * @param $pad (int)  padding bytes at front of shortened block
      * @return array Array of RS values:<ul><li>mm = Bits per symbol;</li><li>nn = Symbols per block;</li><li>alpha_to = log lookup table array;</li><li>index_of = Antilog lookup table array;</li><li>genpoly = Generator polynomial array;</li><li>nroots = Number of generator;</li><li>roots = number of parity symbols;</li><li>fcr = First consecutive root, index form;</li><li>prim = Primitive element, index form;</li><li>iprim = prim-th root of 1, index form;</li><li>pad = Padding bytes in shortened block;</li><li>gfpoly</ul>.
      */
-    protected function init_rs($symsize, $gfpoly, $fcr, $prim, $nroots, $pad) {
+    protected function init_rs($symsize, $gfpoly, $fcr, $prim, $nroots, $pad)
+    {
         foreach ($this->rsitems as $rs) {
-            if (($rs['pad'] != $pad) OR ($rs['nroots'] != $nroots) OR ($rs['mm'] != $symsize)
-                    OR ($rs['gfpoly'] != $gfpoly) OR ($rs['fcr'] != $fcr) OR ($rs['prim'] != $prim)) {
+            if (($rs['pad'] != $pad) or ($rs['nroots'] != $nroots) or ($rs['mm'] != $symsize)
+                or ($rs['gfpoly'] != $gfpoly) or ($rs['fcr'] != $fcr) or ($rs['prim'] != $prim)
+            ) {
                 continue;
             }
             return $rs;
@@ -2601,7 +2706,8 @@ class QRcode {
      * @param $x (int) X position
      * @return int X osition
      */
-    protected function modnn($rs, $x) {
+    protected function modnn($rs, $x)
+    {
         while ($x >= $rs['nn']) {
             $x -= $rs['nn'];
             $x = ($x >> $rs['mm']) + ($x & $rs['nn']);
@@ -2619,23 +2725,24 @@ class QRcode {
      * @param $pad (int)  padding bytes at front of shortened block
      * @return array Array of RS values:<ul><li>mm = Bits per symbol;</li><li>nn = Symbols per block;</li><li>alpha_to = log lookup table array;</li><li>index_of = Antilog lookup table array;</li><li>genpoly = Generator polynomial array;</li><li>nroots = Number of generator;</li><li>roots = number of parity symbols;</li><li>fcr = First consecutive root, index form;</li><li>prim = Primitive element, index form;</li><li>iprim = prim-th root of 1, index form;</li><li>pad = Padding bytes in shortened block;</li><li>gfpoly</ul>.
      */
-    protected function init_rs_char($symsize, $gfpoly, $fcr, $prim, $nroots, $pad) {
+    protected function init_rs_char($symsize, $gfpoly, $fcr, $prim, $nroots, $pad)
+    {
         // Based on Reed solomon encoder by Phil Karn, KA9Q (GNU-LGPLv2)
         $rs = null;
         // Check parameter ranges
-        if (($symsize < 0) OR ($symsize > 8)) {
+        if (($symsize < 0) or ($symsize > 8)) {
             return $rs;
         }
-        if (($fcr < 0) OR ($fcr >= (1 << $symsize))) {
+        if (($fcr < 0) or ($fcr >= (1 << $symsize))) {
             return $rs;
         }
-        if (($prim <= 0) OR ($prim >= (1 << $symsize))) {
+        if (($prim <= 0) or ($prim >= (1 << $symsize))) {
             return $rs;
         }
-        if (($nroots < 0) OR ($nroots >= (1 << $symsize))) {
+        if (($nroots < 0) or ($nroots >= (1 << $symsize))) {
             return $rs;
         }
-        if (($pad < 0) OR ($pad >= ((1 << $symsize) - 1 - $nroots))) {
+        if (($pad < 0) or ($pad >= ((1 << $symsize) - 1 - $nroots))) {
             return $rs;
         }
         $rs = array();
@@ -2645,8 +2752,8 @@ class QRcode {
         $rs['alpha_to'] = array_fill(0, ($rs['nn'] + 1), 0);
         $rs['index_of'] = array_fill(0, ($rs['nn'] + 1), 0);
         // PHP style macro replacement ;)
-        $NN = & $rs['nn'];
-        $A0 = & $NN;
+        $NN = &$rs['nn'];
+        $A0 = &$NN;
         // Generate Galois field lookup tables
         $rs['index_of'][0] = $A0; // log(zero) = -inf
         $rs['alpha_to'][$A0] = 0; // alpha**-inf = 0
@@ -2671,8 +2778,7 @@ class QRcode {
         $rs['nroots'] = $nroots;
         $rs['gfpoly'] = $gfpoly;
         // Find prim-th root of 1, used in decoding
-        for ($iprim = 1; ($iprim % $prim) != 0; $iprim += $rs['nn']) {
-            ; // intentional empty-body loop!
+        for ($iprim = 1; ($iprim % $prim) != 0; $iprim += $rs['nn']) {; // intentional empty-body loop!
         }
         $rs['iprim'] = (int) ($iprim / $prim);
         $rs['genpoly'][0] = 1;
@@ -2703,18 +2809,19 @@ class QRcode {
      * @param $parity (array) parity
      * @return parity array
      */
-    protected function encode_rs_char($rs, $data, $parity) {
-        $MM = & $rs['mm']; // bits per symbol
-        $NN = & $rs['nn']; // the total number of symbols in a RS block
-        $ALPHA_TO = & $rs['alpha_to']; // the address of an array of NN elements to convert Galois field elements in index (log) form to polynomial form
-        $INDEX_OF = & $rs['index_of']; // the address of an array of NN elements to convert Galois field elements in polynomial form to index (log) form
-        $GENPOLY = & $rs['genpoly']; // an array of NROOTS+1 elements containing the generator polynomial in index form
-        $NROOTS = & $rs['nroots']; // the number of roots in the RS code generator polynomial, which is the same as the number of parity symbols in a block
-        $FCR = & $rs['fcr']; // first consecutive root, index form
-        $PRIM = & $rs['prim']; // primitive element, index form
-        $IPRIM = & $rs['iprim']; // prim-th root of 1, index form
-        $PAD = & $rs['pad']; // the number of pad symbols in a block
-        $A0 = & $NN;
+    protected function encode_rs_char($rs, $data, $parity)
+    {
+        $MM = &$rs['mm']; // bits per symbol
+        $NN = &$rs['nn']; // the total number of symbols in a RS block
+        $ALPHA_TO = &$rs['alpha_to']; // the address of an array of NN elements to convert Galois field elements in index (log) form to polynomial form
+        $INDEX_OF = &$rs['index_of']; // the address of an array of NN elements to convert Galois field elements in polynomial form to index (log) form
+        $GENPOLY = &$rs['genpoly']; // an array of NROOTS+1 elements containing the generator polynomial in index form
+        $NROOTS = &$rs['nroots']; // the number of roots in the RS code generator polynomial, which is the same as the number of parity symbols in a block
+        $FCR = &$rs['fcr']; // first consecutive root, index form
+        $PRIM = &$rs['prim']; // primitive element, index form
+        $IPRIM = &$rs['iprim']; // prim-th root of 1, index form
+        $PAD = &$rs['pad']; // the number of pad symbols in a block
+        $A0 = &$NN;
         $parity = array_fill(0, $NROOTS, 0);
         for ($i = 0; $i < ($NN - $NROOTS - $PAD); $i++) {
             $feedback = $INDEX_OF[$data[$i] ^ $parity[0]];
@@ -2737,7 +2844,6 @@ class QRcode {
         }
         return $parity;
     }
-
 }
 
 // end QRcode class


### PR DESCRIPTION
In php 8.1, when using a float value as the array key, it is silently coerced to an int value.
Had to manually cast those keys and for some reason sometimes dynamic keys were floats and didn't exist in array. Not sure about the float() part ...


Modification ligne 815 et 822