### PR TITLE
upgrade twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.4",
     "symfony/http-kernel": "^4.4 || ^5.4 || ^6.4",
     "symfony/options-resolver": "^4.4 || ^5.4 || ^6.4",
-    "twig/twig": "^1.26 || ^2.0 || ^3.0"
+    "twig/twig": "^3.0"
   },
   "suggest": {
     "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.4"

--- a/src/Twig/Extensions/Barcode.php
+++ b/src/Twig/Extensions/Barcode.php
@@ -3,15 +3,14 @@
 namespace SGK\BarcodeBundle\Twig\Extensions;
 
 use SGK\BarcodeBundle\Generator\Generator;
-use Twig_Extension;
-use Twig_SimpleFunction;
-
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 /**
  * Class Project_Twig_Extension
  *
  * @package SGK\BarcodeBundle\Twig\Extensions
  */
-class Barcode extends Twig_Extension
+class Barcode extends AbstractExtension
 {
     /**
      * @var Generator
@@ -32,7 +31,7 @@ class Barcode extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            new Twig_SimpleFunction(
+            new TwigFunction(
                 'barcode',
                 function ($options = array()) {
                     echo $this->generator->generate($options);


### PR DESCRIPTION
### Nouveau comportement

Mise à jour de twig pour gérer les CVE : 
* [CVE-2024-51754][]: Unguarded calls to __toString() when nesting an object into an array
 * [CVE-2024-51755][]: Unguarded calls to __isset() and to array-accesses when the sandbox is enabled